### PR TITLE
Fix comparison methods

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,5 +3,6 @@ MRuby::Gem::Specification.new('mruby-rational') do |spec|
   spec.author  = 'dyama'
   spec.summary = 'Rational class'
 
+  spec.add_dependency('mruby-metaprog')
   spec.add_test_dependency('mruby-enum-ext')
 end

--- a/mrblib/rational.rb
+++ b/mrblib/rational.rb
@@ -4,7 +4,7 @@
 # http://docs.ruby-lang.org/ja/1.9.3/method/Kernel/b/Rational.html
 #
 def Rational(numer, denom = 1)
-  Rational.send :convert, numer, denom
+  Rational.__send__ :convert, numer, denom
 end
 
 ##
@@ -75,6 +75,22 @@ class Rational < Numeric
     else
       nil
     end
+  end
+
+  def <(other)
+    (self <=> other) == -1
+  end
+
+  def <=(other)
+    (self <=> other) <= 0
+  end
+
+  def >(other)
+    (self <=> other) == 1
+  end
+
+  def >=(other)
+    (self <=> other) >= 0
   end
 
   def ==(other)

--- a/test/rational-test.rb
+++ b/test/rational-test.rb
@@ -60,6 +60,38 @@ assert('Rational#<=>') do
   assert_nil(Rational(1, 3) <=> nil)
 end
 
+# < method
+assert('Rational#<') do
+  assert_true(Rational(1, 1) < Rational(2, 1))
+  assert_false(Rational(2, 1) < Rational(1, 1))
+  assert_false(Rational(1, 1) < Rational(1, 1))
+  assert_true(Rational(1, 1) < 2)
+end
+
+# <= method
+assert('Rational#<=') do
+  assert_true(Rational(1, 1) <= Rational(2, 1))
+  assert_true(Rational(1, 1) <= Rational(1, 1))
+  assert_true(Rational(1, 1) <= 1)
+  assert_false(Rational(1, 1) <= Rational(1, 2))
+end
+
+# > method
+assert('Rational#>') do
+  assert_true(Rational(2, 1) > Rational(1, 1))
+  assert_false(Rational(1, 1) > Rational(2, 1))
+  assert_false(Rational(1, 1) > Rational(1, 1))
+  assert_true(Rational(2, 1) > 1)
+end
+
+# >= method
+assert('Rational#>=') do
+  assert_true(Rational(2, 1) >= Rational(1, 1))
+  assert_true(Rational(1, 1) >= Rational(1, 1))
+  assert_false(Rational(1, 1) >= Rational(2, 1))
+  assert_true(Rational(2, 1) >= 1)
+end
+
 # == method
 assert('Rational#==') do
   assert_true(Rational(2, 3) == Rational(2, 3))


### PR DESCRIPTION
In mruby 2.0.1, comparing Rationals using `<` or `>` raises exceptions:

```
mirb - Embeddable Interactive Ruby Shell

> Rational(1, 2) < Rational(1, 4)
(mirb):1: non float value (TypeError)
```

This change ensures `Rational#<=>` is used, which fixes the issue.

It is not yet fixing cases like `1 < Rational(2, 1)`, this would require a monkey patch of Numeric#<=>